### PR TITLE
Fix for shelving order in typeclasses eauto.

### DIFF
--- a/lib/cList.ml
+++ b/lib/cList.ml
@@ -78,6 +78,7 @@ sig
   exception IndexOutOfRange
   val goto : int -> 'a list -> 'a list * 'a list
   val split_when : ('a -> bool) -> 'a list -> 'a list * 'a list
+  val split_with : ('a -> bool) -> 'a list -> 'a list * 'a list
   val split3 : ('a * 'b * 'c) list -> 'a list * 'b list * 'c list
   val firstn : int -> 'a list -> 'a list
   val last : 'a list -> 'a
@@ -681,6 +682,17 @@ let split_when p =
       | (a::l)  -> if (p a) then (List.rev x,y) else split_when_loop (a::x) l
   in
   split_when_loop []
+
+(* [split_with p l] splits [l] into two lists [(l1,l2)] such that
+   [p a=true] for all elements in l1 and [p b = false] for every element [b] of [l2]. *)
+let split_with p =
+  let rec split_with_loop x y ls =
+    match ls with
+      | []      -> (List.rev x, List.rev y)
+      | (l::ls)  -> if p l then split_with_loop (l :: x) y ls
+                   else split_with_loop x (l :: y) ls
+  in
+  split_with_loop [] []
 
 let rec split3 = function
   | [] -> ([], [], [])

--- a/lib/cList.mli
+++ b/lib/cList.mli
@@ -167,6 +167,7 @@ sig
 
 
   val split_when : ('a -> bool) -> 'a list -> 'a list * 'a list
+  val split_with : ('a -> bool) -> 'a list -> 'a list * 'a list
   val split3 : ('a * 'b * 'c) list -> 'a list * 'b list * 'c list
   val firstn : int -> 'a list -> 'a list
   val last : 'a list -> 'a

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1135,8 +1135,11 @@ module Search = struct
           in
           let remaining = CList.map_filter filter shelf in
           (if !typeclasses_debug > 1 then
-             let prunsolved (ev, _) =
-               int (Evar.repr ev) ++ spc () ++ pr_ev sigma ev in
+             let prunsolved (ev, shelve) =
+               int (Evar.repr ev) ++ spc () ++ pr_ev sigma ev ++
+                 (if shelve then str" moving to shelf"
+                  else str" turning into goal")
+             in
              let unsolved = prlist_with_sep spc prunsolved remaining in
              Feedback.msg_debug
                (pr_depth (i :: info.search_depth) ++

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1129,7 +1129,7 @@ module Search = struct
             try
               let evi = Evd.find_undefined sigma ev in
               if info.search_only_classes then
-                Some (ev, is_class_type sigma (Evd.evar_concl evi))
+                Some (ev, not (is_class_type sigma (Evd.evar_concl evi)))
               else Some (ev, true)
             with Not_found -> None
           in
@@ -1147,7 +1147,7 @@ module Search = struct
           begin
             (* Some existentials produced by the original tactic were not solved
                in the subgoals, turn them into subgoals now. *)
-            let shelved, goals = List.split_when (fun (ev, s) -> s) remaining in
+            let shelved, goals = List.split_with (fun (ev, s) -> s) remaining in
             let shelved = List.map fst shelved and goals = List.map fst goals in
             if !typeclasses_debug > 1 && not (List.is_empty goals) then
               Feedback.msg_debug

--- a/tactics/class_tactics.ml
+++ b/tactics/class_tactics.ml
@@ -1124,7 +1124,7 @@ module Search = struct
           else tclDISPATCH
                  (List.init j (fun j' -> (tac_of gls i (Option.default 0 k + j))))
         in
-        let finish sigma =
+        let finish nestedshelf sigma =
           let filter ev =
             try
               let evi = Evd.find_undefined sigma ev in
@@ -1151,8 +1151,8 @@ module Search = struct
             (* Some existentials produced by the original tactic were not solved
                in the subgoals, turn them into subgoals now. *)
             let shelved, goals = List.split_with (fun (ev, s) -> s) remaining in
-            let shelved = List.map fst shelved and goals = List.map fst goals in
-            if !typeclasses_debug > 1 && not (List.is_empty goals) then
+            let shelved = List.map fst shelved @ nestedshelf and goals = List.map fst goals in
+            if !typeclasses_debug > 1 && not (List.is_empty shelved && List.is_empty goals) then
               Feedback.msg_debug
                 (str"Adding shelved subgoals to the search: " ++
                  prlist_with_sep spc (pr_ev sigma) goals ++
@@ -1165,7 +1165,8 @@ module Search = struct
 	         with_shelf (Unsafe.tclEVARS sigma' <*> Unsafe.tclNEWGOALS goals) >>=
                       fun s -> result s i (Some (Option.default 0 k + j)))
           end
-        in res <*> tclEVARMAP >>= finish
+        in with_shelf res >>= fun (sh, ()) ->
+           tclEVARMAP >>= finish sh
       in
       if path_matches derivs [] then aux e tl
       else

--- a/test-suite/success/HintsForward.v
+++ b/test-suite/success/HintsForward.v
@@ -1,0 +1,17 @@
+Parameter pred : nat -> Prop.
+Parameter pred0 : pred 0.
+Parameter f : nat -> nat.
+Parameter predf : forall n, pred n -> pred (f n).
+
+Parameter pred2 : nat -> Prop.
+Lemma foo n : pred n -> pred (S n).
+Admitted.
+
+Hint Extern 0 => match goal with [ H : pred ?n |- _ ] => pose (foo n H) end : bla.
+
+Hint Extern 100000 => shelve : bla.
+
+Goal pred 0 -> True.
+  intros.
+  Set Typeclasses Debug.
+  unshelve typeclasses eauto 4 with bla.

--- a/test-suite/success/Typeclasses.v
+++ b/test-suite/success/Typeclasses.v
@@ -98,7 +98,7 @@ Goal exists R, @Refl nat R.
   solve [typeclasses eauto with foo].
 Qed.
 
-(* Set Typeclasses Compatibility "8.5". *)
+Set Typeclasses Compatibility "8.5".
 Parameter f : nat -> Prop.
 Parameter g : nat -> nat -> Prop.
 Parameter h : nat -> nat -> nat -> Prop.
@@ -108,8 +108,7 @@ Axiom c : forall x y z, h x y z -> f x -> f y.
 Hint Resolve a b c : mybase.
 Goal forall x y z, h x y z -> f x -> f y.
   intros.
-  Set Typeclasses Debug.
-  typeclasses eauto with mybase.
+  Fail Timeout 1 typeclasses eauto with mybase. (* Loops now *)
   Unshelve.
 Abort.
 End bt.
@@ -138,7 +137,8 @@ Notation "'return' t" := (unit t).
 Class A `(e: T) := { a := True }.
 Class B `(e_: T) := { e := e_; sg_ass :> A e }.
 
-Set Typeclasses Debug.
+(* Set Typeclasses Debug. *)
+(* Set Typeclasses Debug Verbosity 2. *)
 
 Goal forall `{B T}, Prop.
   intros. apply a.


### PR DESCRIPTION
Before this fix, unshelve typeclasses eauto would produce sub-goals
in the reverse order compared to when they were first shelved.